### PR TITLE
Fix: Normalize line endings across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Normalize line endings across all platforms
+* text=auto
+
+# Explicitly declare text files
+*.py text
+*.md text
+*.txt text
+*.json text
+*.yaml text
+*.yml text
+
+# Declare files that will always have LF line endings on checkout
+*.sh text eol=lf
+
+# Denote binary files
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.pdf binary


### PR DESCRIPTION
## Summary
Fixes #3 by adding a `.gitattributes` file to normalize line endings across different operating systems.

## Changes
- ✅ Added `.gitattributes` configuration
- ✅ Set `text=auto` for automatic detection
- ✅ Configured LF endings for shell scripts
- ✅ Marked binary files explicitly

## Testing
- [x] Verified on Windows environment
- [x] No more CRLF warnings during git operations
- [x] Committed with normalized line endings

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)